### PR TITLE
Fix severe breakage on Plone 3

### DIFF
--- a/Products/TinyMCE/browser/configure.zcml
+++ b/Products/TinyMCE/browser/configure.zcml
@@ -47,7 +47,9 @@
         <browser:page attribute="jsonConfiguration" name="tinymce-jsonconfiguration" />
     </browser:pages>
 
-    <include package="Products.CMFCore" file="permissions.zcml" />
+    <include package="Products.CMFCore" file="permissions.zcml"
+        xmlns:zcml="http://namespaces.zope.org/zcml"
+        zcml:condition="have plone-41" />
 
     <browser:pages
         for="*"


### PR DESCRIPTION
Update CMFCore permissions include with have plone-41 condition a la Plone 4.1 upgrade guide.
