### PR TITLE
Make sure we override plone.css styles properly in dialog.css so that the...

### DIFF
--- a/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/dialog.css.dtml
+++ b/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/dialog.css.dtml
@@ -6,7 +6,9 @@
 body {
 background: transparent;
 }
-.dialog-wrapper {
+
+/* Make sure we override #content styles from plone.css properly */
+.dialog-wrapper#content {
 font-size: 110%;
 padding: 1em 1em 0em 1em;
 background: &dtml-backgroundColor;;


### PR DESCRIPTION
... latter takes effect.

This fixes style issues which seem to appear in Plone 4.1 on some configurations.

The bug:

http://imagebin.org/196440
