### PR TITLE
Remove inline style & fix layout of WYSIWYG editor toggle

### DIFF
--- a/Products/TinyMCE/skins/tinymce/tinymce_wysiwyg_support.pt
+++ b/Products/TinyMCE/skins/tinymce/tinymce_wysiwyg_support.pt
@@ -23,7 +23,7 @@
                             class python:wysiwyg and 'mce_editable' or None"></textarea>
 
   <div tal:condition="wysiwyg"
-       class="discreet suppressVisualEditor" style="margin-top: -1em;">
+       class="discreet suppressVisualEditor">
     <a i18n:translate="suppress_visual_editor"
        i18n:domain="plone.tinymce"
        tal:attributes="href string:${request/URL0}?tinymce.suppress=${fname}&amp;${request/QUERY_STRING};">


### PR DESCRIPTION
Previously looked like example at: http://awesomeco.de/tinymce-visual.png

Corrected pull request from #9.
