### PR TITLE
Fix plonebrowser image description

### DIFF
--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -638,7 +638,7 @@ BrowserDialog.prototype.setDetails = function (url) {
                 self.thumb_url = "";
             }
 
-            jq('#description', document).val(data.description);
+            jq('#description', document).val(decodeURIComponent(data.description));
             jq('#description_href', document).val(data.url);
 
             // Repopulate the <option>s in the dimensions <select> element.


### PR DESCRIPTION
Image description is URI encoded and sent to /tinymce-setDescription.
When you want to change/update the image in plonebrowser the description is displayed in the URI encoded format (%20 and that sort of thing).
With this commit the description is decoded before being set as description field val.
