### PR TITLE
Fix anchor list titles

### DIFF
--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -1057,7 +1057,10 @@ BrowserDialog.prototype.populateAnchorList = function () {
     nodes_length = nodes.length;
     if (nodes.length > 0) {
         for (i = 0; i < nodes_length; i++) {
-            title = nodes[i].innerHTML;
+            title = jq(nodes[i]).text().replace(/^\s+|\s+$/g, '');
+            if (title==='') {
+            	continue;
+            }
             title_match = title.match(/mceItemAnchor/);
             if (title_match === null) {
                 name = title.toLowerCase();


### PR DESCRIPTION
Currently if a heading includes other markup such as <img> tags, these are included in the title with any non alphabetical characters changed into '-'s. Also, any empty headings are also included in the list, showing blank options. This change means that the anchor link options only use text from the headings & does not list empty headings.
