### PR TITLE
Use "nocall:"

### DIFF
--- a/Products/TinyMCE/skins/tinymce/tinymce_wysiwyg_support.pt
+++ b/Products/TinyMCE/skins/tinymce/tinymce_wysiwyg_support.pt
@@ -6,7 +6,7 @@
   <tal:block define="field field|nothing;
                      fname fieldName|inputname|nothing;
                      force_wysiwyg force_wysiwyg|nothing;
-                     object object|here;
+                     object nocall:object|here;
                      text_format python:here.portal_tinymce.getContentType(object=object, field=field, fieldname=fname);
                      suppressed python:request.form.get('tinymce.suppress') == fname;
                      wysiwyg python:(not suppressed and 'html' in text_format.lower()) or force_wysiwyg;


### PR DESCRIPTION
Use "nocall:". We do not want to render the object, but call a method on it. And this will also make the widget work (somewhat) when used in z3c-based portlets.
