### PR TITLE
Link by UID by default.

### DIFF
--- a/Products/TinyMCE/profiles/default/tinymce.xml
+++ b/Products/TinyMCE/profiles/default/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <object>
  <resourcetypes>
-  <link_using_uids value="False"/>
+  <link_using_uids value="True"/>
   <allow_captioned_images value="False"/>
   <rooted value="False"/>
   <linkable>


### PR DESCRIPTION
We set this in our base policy for every project, so it seems more sensible to enable this by default instead of overriding this.
