### PR TITLE
Fix for missing popups when zoom is applied in Chrome.

### DIFF
--- a/Products/TinyMCE/skins/tinymce/plugins/inlinepopups/skins/plonepopup/window.css.dtml
+++ b/Products/TinyMCE/skins/tinymce/plugins/inlinepopups/skins/plonepopup/window.css.dtml
@@ -47,7 +47,7 @@
 .plonepopup .mceMiddle, .plonepopup .mceMiddle div {top:0}
 .plonepopup .mceMiddle {width:100%; height:100%; clip:rect(25px auto auto auto); background-color: White}
 .plonepopup .mceMiddle .mceLeft {left:0; width:5px; height:100%; background-color: White; clip: rect(auto 4px auto 1px)}
-.plonepopup .mceMiddle span {top:29px; left:5px; height:100%; background:#FFF}
+.plonepopup .mceMiddle span {top:29px; left:5px; height:100%; width:100%; background:#FFF}
 .plonepopup .mceMiddle .mceRight {right:0; width:5px; height:100%; background-color: White; clip: rect(auto 4px auto 1px)}
 
 /* Bottom */


### PR DESCRIPTION
When zoom is applied (either positive or negative zoom) in Chrome the popups appears empty, for example the table popup, but applies to both image browser and content browser for the link feature, the little change in the stylesheet fixes the problem. The solution was found by @raekjaer.
