### PR TITLE
Make breadcrumbs work (fix context when loading tiny_mce_gzip.js)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ HISTORY
 1.3b6 (unreleased)
 ------------------
 
+- Take context into account so breadcrumbs work e.g. for internal links and
+  images [huubbouma]
+
 - Don't break when running portal_setup > import on non-English sites having international
   characters in TinyMCE settings [miohtama]
 

--- a/Products/TinyMCE/browser/browser.py
+++ b/Products/TinyMCE/browser/browser.py
@@ -211,6 +211,16 @@ class ConfigurationViewlet(ViewletBase):
     index = ViewPageTemplateFile('configuration.pt')
     suffix = ''
 
+    def get_context_url(self):
+        """ return the context, but take portal_factory into account """
+        context = aq_inner(self.context)
+        factory = getToolByName(context, 'portal_factory', None)
+        # Are we in an archetype factory context?
+        if factory is not None and factory.isTemporary(context):
+            return context.aq_parent.aq_parent.aq_parent.absolute_url()
+
+        return context.absolute_url()
+
     def getATRichTextFieldNames(self):
         """ Get names of Archetype richtext fields """
         schema = self.context.Schema()

--- a/Products/TinyMCE/browser/configuration.pt
+++ b/Products/TinyMCE/browser/configuration.pt
@@ -1,3 +1,3 @@
 <script type="text/javascript"
     tal:condition="view/show"
-    tal:attributes="src string:${context/absolute_url}/tiny_mce_gzip.js${view/suffix}"></script>
+    tal:attributes="src string:${view/get_context_url}/tiny_mce_gzip.js${view/suffix}"></script>


### PR DESCRIPTION
I've fixed the call to tiny_mce_gzip.js which would always load from the portal root. Now it loads relatively from the current context, so the breadcrumbs work when you create an internal link or select an image.

Cheers, Huub
