### PR TITLE
Check if the context is IFolderish even when checkCreationFlag isn't available

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ HISTORY
 1.3b7 (unreleased)
 ------------------
 
+- If the context isn't IFolderish, then the parent really should be,
+  since it's got the context in it.
+  [lentinj]
+
 - Check if the context is IFolderish even when checkCreationFlag isn't
   available, i.e. when it's a Dexterity content type
   [lentinj]

--- a/Products/TinyMCE/utility.py
+++ b/Products/TinyMCE/utility.py
@@ -949,7 +949,7 @@ class TinyMCE(SimpleItem):
                     # is Folderish, so can add images there.
                     results['document_base_url'] = context.absolute_url() + "/"
                 else:
-                    results['document_base_url'] = results['portal_url'] + "/"
+                    results['document_base_url'] = parent.absolute_url() + "/"
         except AttributeError:
             results['document_base_url'] = results['portal_url'] + "/"
             results['document_url'] = results['portal_url']


### PR DESCRIPTION
Without this Products.TinyMCE always adds images to the root of the site by default.
