### PR TITLE
Remove use of base_properties from css.dtml files.

### DIFF
--- a/Products/TinyMCE/skins/tinymce/plugins/inlinepopups/skins/plonepopup/window.css.dtml
+++ b/Products/TinyMCE/skins/tinymce/plugins/inlinepopups/skins/plonepopup/window.css.dtml
@@ -1,5 +1,3 @@
-/* <dtml-with base_properties> */
-
 /* Plone Popup */
 
 /* Reset */
@@ -101,7 +99,7 @@
 /* Alert/Confirm */
 .plonepopup .mceButton {font-weight:normal; height: 14px; width: auto; bottom:12px; background: white url(img/button.gif) no-repeat scroll 9px 1px; padding:1px 8px 1px 18px; outline:0; color: Black; }
 .plonepopup .mceMiddle .mceIcon {left:15px; top:35px; width:32px; height:32px}
-.plonepopup .mceAlert .mceMiddle span, .plonepopup .mceConfirm .mceMiddle span {background:&dtml-backgroundColor;;left:5px; top:19px; width:366px; height:82px; font-weight:normal; color: Black; overflow:auto; white-space:normal;padding:12px;}
+.plonepopup .mceAlert .mceMiddle span, .plonepopup .mceConfirm .mceMiddle span {background:White;left:5px; top:19px; width:366px; height:82px; font-weight:normal; color: Black; overflow:auto; white-space:normal;padding:12px;}
 .plonepopup a:hover {font-weight:normal;}
 .plonepopup .mceAlert .mceMiddle, .plonepopup .mceConfirm .mceMiddle {}
 .plonepopup .mceAlert .mceOk {left:12px; top:auto}
@@ -109,5 +107,3 @@
 .plonepopup .mceConfirm .mceOk {left:80px; top:auto}
 .plonepopup .mceConfirm .mceCancel {left:12px; top:auto}
 .plonepopup .mceConfirm .mceIcon {display: none;}
-
-/* </dtml-with> */

--- a/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/content.css.dtml
+++ b/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/content.css.dtml
@@ -1,5 +1,3 @@
-/* <dtml-with base_properties> */
-/* <dtml-call "REQUEST.set('portal_url', portal_url())"> */
 body.mceForceColors {background:#FFF; color:#000;}
 
 .mceContentBody {
@@ -7,7 +5,7 @@ body.mceForceColors {background:#FFF; color:#000;}
 }
 
 .mceContentBody a {
-    color: &dtml-linkColor; !important;
+    color: #205C90 !important;
     background-color: transparent;
     text-decoration: none !important;
     border-bottom: 1px #cccccc solid !important;
@@ -23,5 +21,3 @@ del {color:red; text-decoration:line-through}
 cite {border-bottom:1px dashed blue}
 acronym {border-bottom:1px dotted #CCC; cursor:help}
 abbr, html\:abbr {border-bottom:1px dashed #CCC; cursor:help}
-
-/* </dtml-with> */

--- a/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/dialog.css.dtml
+++ b/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/dialog.css.dtml
@@ -1,4 +1,3 @@
-/* <dtml-with base_properties> */
 /* <dtml-call "REQUEST.set('portal_url', portal_url())"> */
 
 @import "<dtml-var portal_url>/plone.css";
@@ -11,7 +10,7 @@ background: transparent;
 .dialog-wrapper#content {
 font-size: 110%;
 padding: 1em 1em 0em 1em;
-background: &dtml-backgroundColor;;
+background: white;
 margin: 0!important;
 }
 
@@ -141,6 +140,5 @@ background: transparent;
 color: inherit;
 font-weight: normal;
 }
-/* </dtml-with> */
 
 .verticalborder { height: 330px; width: 0px; border-right: 0.1em solid #329FD7; margin: 10px 20px 10px 20px }

--- a/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/ui.css.dtml
+++ b/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/ui.css.dtml
@@ -1,4 +1,4 @@
-/* <dtml-with base_properties><dtml-with portal_tinymce> */
+/* <dtml-with portal_tinymce> */
 
 /* Save message */
 .mceSaveMessage {
@@ -244,4 +244,4 @@
 /* Fullscreen editing */
 #mce_fullscreen_container {background-color: #fff}
 
-/* </dtml-with> </dtml-with> */
+/* </dtml-with> */


### PR DESCRIPTION
`base_properties` is not available when using unstyled Plone. This leads to an (almost) invisible tinymce toolbar because some css files fail to load. In the error log you get:

```
NameError: name 'base_properties' is not defined
```

See https://dev.plone.org/ticket/13416
