### PR TITLE
Fixed internallink isue with Plone 4.3

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ HISTORY
 1.3b10 (unreleased)
 -------------------
 
+- Fixed selection of an item in the home folder.
+  [vincentpretre]
+
 - Removed use of base_properties from css.dtml files.
   [maurits+thomvl]
 

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -760,10 +760,10 @@ BrowserDialog.prototype.setDetails = function (url) {
             self.displayPanel('details');
 
             // select radio button in folder listing and mark selected image
-            jq('input:radio[name=internallink][value!=' + data.uid_relative_url + ']', document)
+            jq('input:radio[name=internallink][value!="' + data.uid_relative_url + '"]', document)
                 .parent('.item')
                 .removeClass('current');
-            jq('input:radio[name=internallink][value=' + data.uid_relative_url + ']', document)
+            jq('input:radio[name=internallink][value="' + data.uid_relative_url + '"]', document)
                 .attr('checked', 'checked')
                 .parent('.item')
                 .addClass('current');


### PR DESCRIPTION
There's a bug when using TinyMCE with Plone 4.3 (it might be due to the fact that Plone 4.3 uses jQuery 1.7.2).
- start a fresh Plone 4.3 site (in my case I changed the buildout.cfg at the root of Products.TinyMCE to extend http://dist.plone.org/release/4.3-latest/versions.cfg).
- edit the front-page and select a word
- click on the button to insert a link
- try to make a link to "Agenda"

All values are now shown as current and the latest radio input is checked.
Apparently the problem came from the way the radio input was selected (maybe the slash in the resolve_uid ? )
