### PR TITLE
Fixed check dependency on plone.namedfile

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ HISTORY
 1.2.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed ``plone.namedfile`` dependecy check
+  [keul]
 
 
 1.2.15 (2013-01-13)

--- a/Products/TinyMCE/adapters/Upload.py
+++ b/Products/TinyMCE/adapters/Upload.py
@@ -13,6 +13,7 @@ from plone.outputfilters.browser.resolveuid import uuidFor
 import pkg_resources
 try:
     pkg_resources.get_distribution('plone.dexterity')
+    pkg_resources.get_distribution('plone.namedfile')
 except pkg_resources.DistributionNotFound:
     HAS_DEXTERITY = False
     pass


### PR DESCRIPTION
I found an uncommon situation on Plone 4.2.

If the `plone.dexterity` (but **not plone.app.dexterity**) is present in the buildout, TinyMCE is not working because the `HAS_DEXTERITY` check is only looking for `plone.dexterity`, the using also `plone.namedfile`.
This can happen when add-ons (like collective.lorepipsum) are installing plone.dexterity as dependency.

Until dexterity will be part of Plone core, I think that this dependency must be changed as in this pull request (or changing the check on the whole `plone.app.dexterity`.

Probably the same fix must be ported on the master/TinyMCE 1.3.x
