### PR TITLE
Fixed broken long titles in dialog window.

### DIFF
--- a/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/dialog.css.dtml
+++ b/Products/TinyMCE/skins/tinymce/themes/advanced/skins/plone/dialog.css.dtml
@@ -106,6 +106,7 @@ margin-left: 0.5em;
 #internallinkcontainer .list.item span,
 #internallinkcontainer .list.item a {
 position: absolute;
+white-space: nowrap;
 }
 
 /* InputPanel */


### PR DESCRIPTION
If titles are long they are overwritten because of combination of absolute positioning and wrapping. 'white-space: nowrap' solves the problem.
