### PR TITLE
Added enable_tinymce_livesearch property for livesearch functionality

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,8 +2,14 @@
 HISTORY
 =======
 
-1.2.17 (unreleased)
--------------------
+1.2.17.dev0 (unreleased)
+------------------------
+
+- Check for a 'enable_tinymce_livesearch'property in order to override the 
+  enable_livesearch of site_properties for instances where you want to have
+  livesearch enabled on the portal_search and yet you do not want it enabled
+  within TinyMCE and the other way around
+  [ichim-david]
 
 - Fixed charset in source editor for non en languages.
   [kroman0]

--- a/Products/TinyMCE/utility.py
+++ b/Products/TinyMCE/utility.py
@@ -814,7 +814,8 @@ class TinyMCE(SimpleItem):
         results['entity_encoding'] = self.entity_encoding
 
         props = getToolByName(self, 'portal_properties')
-        livesearch = props.site_properties.getProperty('enable_livesearch', False)
+        plone_livesearch = props.site_properties.getProperty('enable_livesearch', False)
+        livesearch = props.site_properties.getProperty('enable_tinymce_livesearch', plone_livesearch)
         if livesearch:
             results['livesearch'] = True
         else:


### PR DESCRIPTION
The reasoning for this pull request is the fact that there could be a use case where you would want to have livesearch enabled within the site but not the tinymce searches and the other way around
