### PR TITLE
Convert all links to absolute links otherwise one cannot include links in static portlets

### DIFF
--- a/Products/TinyMCE/browser/browser.py
+++ b/Products/TinyMCE/browser/browser.py
@@ -124,7 +124,7 @@ class TinyMCEBrowserView(BrowserView):
         utility = getToolByName(aq_inner(self.context), 'portal_tinymce')
         return json.dumps(utility.getConfiguration(context=self.context,
                                                    field=field,
-                                                   request=self.request)) 
+                                                   request=self.request))
 
 
 class ATDProxyView(object):


### PR DESCRIPTION
Without `relative_urls = false` one cannot edit a static portlet with urls, see http://stackoverflow.com/a/5199657/1129950

Steps to reproduce:
1. Create a static portlet at site portal or somewhere else
2. Try to have a link like this in it: `<a href="/feed/RSS" title="Follow us here">`, e.g. by using the plain html mode of TinyMCE
3. Damn it, does not work. The link gets converted to `<a href="/feed/RSS" title="Follow us here">` (relative url now)

See also: http://www.tinymce.com/wiki.php/Configuration:convert_urls and http://www.tinymce.com/wiki.php/Configuration:relative_urls
