### PR TITLE
Move upload button of content browser on the right of search widgets

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,10 @@ HISTORY
 1.3.6 (unreleased)
 ------------------
 
+- Move upload button of content browser on the right of search widgets
+  instead of in the footer, where user often miss it.
+  [thomasdesvenain]
+
 - French translations.
   [thomasdesvenain]
 

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/css/plonebrowser.css
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/css/plonebrowser.css
@@ -23,9 +23,9 @@
 #details_panel #description { width: 100%; }
 #addimage_panel input, #addimage_panel textarea { width: 100%; }
 #addimage_panel #upload_iframe { display: none; }
-#searchtext { float:left; width: 70%; max-width:500px; height: 20px; border: 1px solid #CCC; margin-bottom: 5px; padding-left: 4px; }
+#searchtext { float:left; width: 60%; max-width:500px; height: 20px; border: 1px solid #CCC; margin-bottom: 5px; padding-left: 4px; }
 #clear-btn { display: none; margin-left: -20px; margin-top: 2px; float:left;; border: none!important; }
-#search-btn { border: none!important; margin-top: 2px; margin-left: 5px; float:left; }
+#search-btn, #upload { border: none!important; margin-top: 2px; margin-left: 5px; float:left; }
 #description { border: 1px solid #CCC; }
 #uploadbutton { margin-top: 10px; }
 #previewimagecontainer { text-align: center; }
@@ -51,7 +51,6 @@
 #insert-selection { margin: 0.7em auto; display: block; width: 70%; }
 #footer { position: absolute; bottom: 0; width: 97.75%; }
 #footer #action-button { margin-bottom: 10px; margin-left: -24.87%; }
-#footer #upload-button { margin-top: 13px; }
 input[disabled] { background: #F6F6F6; border: 1px solid #E6E6E6; color: #B2C3D9; }
 .field input[type="text"][name$=".title"], input#title { width: auto!important; }
 

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -680,9 +680,9 @@ BrowserDialog.prototype.checkSearch = function (e) {
     }
 
     // Activate search when we have enough input and either livesearch is
-    // enabled or the user explicitly pressed Enter (which === 13), or the user 
-    // clicks (which === 1) on the search icon 
-    if (len >= 3 && (this.tinyMCEPopup.editor.settings.livesearch === true 
+    // enabled or the user explicitly pressed Enter (which === 13), or the user
+    // clicks (which === 1) on the search icon
+    if (len >= 3 && (this.tinyMCEPopup.editor.settings.livesearch === true
                     || e.which === 13 || e.which === 1)) {
         this.is_search_activated = true;
         this.getFolderListing(this.tinyMCEPopup.editor.settings.navigation_root_url, this.method_search);
@@ -1143,10 +1143,10 @@ BrowserDialog.prototype.displayPanel = function(panel, upload_allowed) {
         }
         jq('#browseimage_panel', document).removeClass('hide').addClass('row');
         jq('#insert-selection', document).attr('disabled','disabled');
-        jq('#upload-button', document).removeClass('hide');
+        jq('#upload', document).removeClass('hide');
     } else {
         jq('#browseimage_panel', document).removeClass('row').addClass('hide');
-        jq('#upload-button', document).addClass('hide');
+        jq('#upload', document).addClass('hide');
     }
 
     // handle details/preview panel

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/plonebrowser.htm.pt
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/plonebrowser.htm.pt
@@ -42,7 +42,9 @@
                         <input type="text" name="searchtext" id="searchtext" title="Search site" placeholder="Search site" value="" i18n:attributes="placeholder; title" i18n:domain="plone.tinymce"/>
                         <a href="" id="clear-btn" title="Clear" i18n:attributes="title" i18n:domain="plone.tinymce"><img src="img/cancel.png" /></a>
                         <a href="" id="search-btn" title="Search" i18n:attributes="title" i18n:domain="plone.tinymce"><img src="img/magnifier.png" /></a>
+			            <a id="upload" href=""><img src="img/application_get.png" /> <i18n:translate translate="" domain="plone.tinymce">Upload</i18n:translate></a>
                     </div>
+
                 </div>
                 <div class="legend">
                     <a id="listview" href="" title="List view" i18n:attributes="title" i18n:domain="plone.tinymce"><img src="img/display_list.png" /></a>
@@ -258,9 +260,6 @@
         <div class="visualClear"><!-- --></div>
 
         <div id="footer" class="row">
-            <div id="upload-button" class="cell width-3:4 position-0 hide">
-                <img src="img/application_get.png" /> <a id="upload" href="" i18n:translate="" i18n:domain="plone.tinymce">Upload</a>
-            </div>
             <div id="action-button" class="cell width-1:4 position-3:4">
                 <input type="submit" id="insert-selection" class="context plonebutton" name="insert-image"
                        i18n:attributes="value" i18n:domain="plone.tinymce" value="OK" disabled="disabled" />


### PR DESCRIPTION
  instead of in the footer, where user often miss it.

This pull request is based on the real experience that many users miss the 'upload' button that was in the footer.
The goal is to make it more visible, but is also to provide a UI that matches with a 'good practice' user story : user wants to include a content into his document, first he searches it already exists in the site, if it doesn't, there he uploads it.
