### PR TITLE
Fix missing id for dx files - really fixes #13759

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ HISTORY
 1.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixes missing id for dx files - really fixes (close `#13759`__)
+  [gomez]
 
 
 1.3.6 (2014-02-19)

--- a/Products/TinyMCE/adapters/Upload.py
+++ b/Products/TinyMCE/adapters/Upload.py
@@ -162,7 +162,7 @@ class Upload(object):
                 obj.description = description
 
         if HAS_DEXTERITY and IDexterityContent.providedBy(obj):
-            if not self.setDexterityItem(obj, uploadfile):
+            if not self.setDexterityItem(obj, uploadfile, id):
                 return self.errorMessage(
                     _("The content-type '%s' has no blob-field!" % metatype))
         else:
@@ -182,7 +182,7 @@ class Upload(object):
             path = obj.absolute_url()
         return self.okMessage(path, folder)
 
-    def setDexterityItem(self, obj, uploadfile):
+    def setDexterityItem(self, obj, uploadfile, id):
         """ Set the blob-field of dexterity-based types
 
         This works with blob-types of plone.app.contenttypes and has


### PR DESCRIPTION
Upload of PDF wasnt possible. This fixes the correct id for dx types.