### PR TITLE
Call convertURL when inserting link or image.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,11 @@ HISTORY
 1.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Call convertURL when inserting link or image.
+  Fixes `#13721`__.
+  [maurits]
+
+__ https://dev.plone.org/ticket/13721
 
 
 1.3.6 (2014-02-19)

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -488,7 +488,8 @@ BrowserDialog.prototype.insertLink = function () {
 
     switch (active_panel) {
         case "#internal":
-            link = this.current_link;
+            link = this.editor.convertURL(this.current_link);
+
             anchor = jq('#pageanchor', document).val();
             if (anchor) {
                 link += '#' + anchor;
@@ -586,7 +587,7 @@ BrowserDialog.prototype.insertLink = function () {
 BrowserDialog.prototype.insertImage = function () {
     var attrs = {},
         selected_node = this.editor.selection.getNode(),
-        href = this.current_link,
+        href = this.editor.convertURL(this.current_link),
         active_panel = jq('#linktype .current a', document).attr('href'),
         dimension,
         classes;


### PR DESCRIPTION
Call convertURL when inserting a link or image. This fixes https://dev.plone.org/ticket/13721: "TinyMCE saves internal links as absolute urls, if UID support is inactive".

Note: the fix has no adverse effect when UID support is active, as far as I see.
