### PR TITLE
Fixed current image scale in image popups

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ HISTORY
 1.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed current image scale in image popups
+  [huubbouma]
 
 
 1.4.2 (2014-11-01)

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -347,8 +347,8 @@ BrowserDialog.prototype.init = function () {
             } else {
                 scaled_image = this.parseImageScale(selected_node.attr("src"));
 
-                // Update the dimensions <select> with the corresponding value.
-                jq('#dimensions', document).val(scaled_image.scale);
+                // Store the selected scale on the dimensions <select>.
+                jq('#dimensions', document).data('selectedScale', scaled_image.scale);
 
                 if (scaled_image.url.indexOf('resolveuid/') > -1) {
                     /** Handle UID linked image **/
@@ -731,7 +731,7 @@ BrowserDialog.prototype.setDetails = function (url) {
         'url': url + '/tinymce-jsondetails',
         'dataType': 'json',
         'success': function (data) {
-            var dimension = jq('#dimensions', document).val(),
+            var dimension = jq('#dimensions', document).data('selectedScale'),
                 dimensions,
                 i;
 


### PR DESCRIPTION
There's a bug in the current TinyMCE image popup in plone: The previous selected scale is not selected when the popup is loaded. This has to do with the asynchronoous handling of the different ajax calls.
I fixed it by setting the current scale with a data attribute on the select, which is later used when adding the items.