### PR TITLE
make upload work with sites using diazo 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,10 @@ HISTORY
 1.3.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- deactivate diazo for ``@@tinymce-upload`` view to make
+  sure ``uploadOk`` script is called to update the
+  content browser panel.
+  [fRiSi]
 
 
 1.3.10 (2015-06-26)

--- a/Products/TinyMCE/browser/browser.py
+++ b/Products/TinyMCE/browser/browser.py
@@ -30,6 +30,8 @@ class TinyMCEBrowserView(BrowserView):
     def upload(self):
         """Upload a file to the zodb"""
 
+        # keep diazo from touching this page
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
         context = IUpload(self.context)
         return context.upload()
 


### PR DESCRIPTION
if diazo rules are applied to the html returned by `@@tinymce-upload` the call of the javascript function `window.parent.uploadOk` that updates the content listing and also activates the image inserting dialog for the uploaded image might get lost.
this way we make sure that diazo is not getting into our way.