### PR TITLE
Fixed current image scale in image popups

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ HISTORY
 1.3.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed current image scale in image popups
+  [huubbouma]
 
 
 1.3.10 (2015-06-26)

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -349,8 +349,8 @@ BrowserDialog.prototype.init = function () {
             } else {
                 scaled_image = this.parseImageScale(selected_node.attr("src"));
 
-                // Update the dimensions <select> with the corresponding value.
-                jq('#dimensions', document).val(scaled_image.scale);
+                // Store the selected scale on the dimensions <select>.
+                jq('#dimensions', document).data('selectedScale', scaled_image.scale);
 
                 if (scaled_image.url.indexOf('resolveuid/') > -1) {
                     /** Handle UID linked image **/
@@ -739,7 +739,7 @@ BrowserDialog.prototype.setDetails = function (url) {
         'url': url + '/tinymce-jsondetails',
         'dataType': 'json',
         'success': function (data) {
-            var dimension = jq('#dimensions', document).val(),
+            var dimension = jq('#dimensions', document).data('selectedScale'),
                 dimensions,
                 i;
 


### PR DESCRIPTION
apply changes from https://github.com/plone/Products.TinyMCE/pull/84 to 1.3.x branch too