### PR TITLE
let upload adapter check permissions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,9 @@ HISTORY
 - Declares missing dependency on plone.fieldsets
   [davilima6]
 
+- Let upload adapter check permissions
+  [tschorr]
+
 
 1.4.3 (2015-06-05)
 ------------------

--- a/Products/TinyMCE/browser/configure.zcml
+++ b/Products/TinyMCE/browser/configure.zcml
@@ -58,6 +58,7 @@
         <browser:page attribute="jsonImageSearch" name="tinymce-jsonimagesearch" />
         <browser:page attribute="jsonDetails" name="tinymce-jsondetails" />
         <browser:page attribute="jsonConfiguration" name="tinymce-jsonconfiguration" />
+        <browser:page attribute="upload" name="tinymce-upload" />
     </browser:pages>
 
 
@@ -67,13 +68,6 @@
         permission="cmf.ModifyPortalContent">
         <browser:page attribute="save" name="tinymce-save" />
         <browser:page attribute="setDescription" name="tinymce-setDescription" />
-    </browser:pages>
-
-    <browser:pages
-        for="*"
-        class=".browser.TinyMCEBrowserView"
-        permission="cmf.AddPortalContent">
-        <browser:page attribute="upload" name="tinymce-upload" />
     </browser:pages>
 
     <browser:resourceDirectory


### PR DESCRIPTION
adapters/Upload does it's own error handling and displays appropriate messages to the user, but the permission setting in configure.zcml will eventually cause an Unauthorized exception before we get there.