### PR TITLE
fix `path` expression in `wysiwyg_support`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,10 @@ Fixes:
 - Let upload adapter check permissions
   [tschorr]
 
+- fix `path` expression in `wysiwyg_support`;
+  `plone.app.z3cform` support for `collective.ckeditor` where 
+  `ckeditor_wysiwyg_support` is a view rather than a skin
+
 - *add item here*
 
 

--- a/Products/TinyMCE/skins/tinymce/wysiwyg_support.pt
+++ b/Products/TinyMCE/skins/tinymce/wysiwyg_support.pt
@@ -7,7 +7,7 @@
                      default_editor python: context.portal_properties.site_properties.getProperty('default_editor');
                      default_editor python: (default_editor or 'None').lower();
                      editor python: test(member_editor=='', default_editor, member_editor);
-                     support python: editor.lower() == 'none' and path('nocall:here/portal_skins/plone_wysiwyg/wysiwyg_support') or path('nocall:here/%s_wysiwyg_support|here/%s/wysiwyg_support|here/%s_wysiwyg_support|here/%s/wysiwyg_support|here/portal_skins/plone_wysiwyg/wysiwyg_support' % (editor, editor, default_editor, default_editor));">
+                     support python: editor.lower() == 'none' and path('nocall:here/portal_skins/plone_wysiwyg/wysiwyg_support') or path('nocall:here/@@%s_wysiwyg_support|here/%s_wysiwyg_support|here/%s/wysiwyg_support|here/@@%s_wysiwyg_support|here/%s_wysiwyg_support|here/%s/wysiwyg_support|here/portal_skins/plone_wysiwyg/wysiwyg_support' % (editor, editor, editor, default_editor, default_editor, default_editor));">
    <metal:block metal:use-macro="support/macros/wysiwygEditorBox">
    </metal:block>
   </tal:block>


### PR DESCRIPTION
`plone.app.z3cform` support for `collective.ckeditor` where
`ckeditor_wysiwyg_support` is a view rather than a skin