### PR TITLE
tinymce-jsonconfiguration declares correct content type

### DIFF
--- a/Products/TinyMCE/browser/browser.py
+++ b/Products/TinyMCE/browser/browser.py
@@ -124,6 +124,10 @@ class TinyMCEBrowserView(BrowserView):
         """Return the configuration in JSON"""
 
         utility = getToolByName(aq_inner(self.context), 'portal_tinymce')
+        self.request.RESPONSE.setHeader(
+            'content-type',
+            'application/json;charset=utf-8'
+        )
         return json.dumps(utility.getConfiguration(context=self.context,
                                                    field=field,
                                                    request=self.request))

--- a/Products/TinyMCE/tests/test_widget_settings.py
+++ b/Products/TinyMCE/tests/test_widget_settings.py
@@ -59,12 +59,18 @@ class WidgetSettingTestCase(FunctionalTestCase):
         to the generated config JSON.
         """
         dummy = self.mockAtContent()
-        view = getMultiAdapter((dummy, self.portal.REQUEST), name="tinymce-jsonconfiguration")
+        view = getMultiAdapter(
+            (dummy, self.portal.REQUEST.clone()),
+            name="tinymce-jsonconfiguration"
+        )
         view = view.__of__(dummy)
 
         # Settings output as JSON
         output = view(field=dummy.getField('testfield'))
-
+        self.assertEqual(
+            view.request.response.getHeader('content-type'),
+            'application/json;charset=utf-8',
+        )
         data = json.loads(output)
 
         # No other buttons should be available


### PR DESCRIPTION
Fixes #125.

This is for Plone 4.3, once it is closed I can cherry pick the changes to master.
