### PR TITLE
Show anchor dropdown for internal links again if it was empty once

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,7 +11,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Show the anchor dropdown for internal links again if it was empty once.
+  [msom]
 
 
 1.3.17 (2016-01-08)

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -800,6 +800,7 @@ BrowserDialog.prototype.setDetails = function (url) {
                     html += '<option value="' + data.anchors[i] + '">' + data.anchors[i] + '</option>';
                 }
                 jq('#pageanchor', document).append(html);
+                jq('#pageanchorcontainer', document).parents('.field').removeClass('hide');
             } else {
                 jq('#pageanchorcontainer', document).parents('.field').addClass('hide');
             }


### PR DESCRIPTION
The dropdown is not visible if it once has been empty.