### PR TITLE
Fix listing of internal anchors in the plonebrowser dialog

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,7 +11,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fixed bug where the plonebrowser dialog wouldn't properly populate the
+  anchors if the HTML5 schema was used.
+  [msom]
 
 
 1.3.17 (2016-01-08)

--- a/Products/TinyMCE/browser/atanchors.py
+++ b/Products/TinyMCE/browser/atanchors.py
@@ -18,6 +18,7 @@ except ImportError:
 
     SEARCHPATTERN = "*/a"
 
+
 class ATAnchorView(BrowserView):
     implements(IAnchorView)
 
@@ -38,5 +39,11 @@ class ATAnchorView(BrowserView):
             raise
         except Exception:
             return []
-        return [anchor.get('name') for anchor in tree.findall(SEARCHPATTERN)
-                if "name" in anchor.keys()]
+
+        anchors = []
+        for anchor in tree.findall(SEARCHPATTERN):
+            if "name" in anchor.keys():
+                anchors.append(anchor.get('name'))
+            if "id" in anchor.keys():
+                anchors.append(anchor.get('id'))
+        return anchors


### PR DESCRIPTION
There is another bug related to https://github.com/plone/Products.TinyMCE/pull/130 (https://github.com/tinymce/tinymce/commit/970f0c662f50515e48fe046bba704126a8f30c40).

The links are also not shown for the internal links dropdown.