### PR TITLE
Cleanup import

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,11 @@ New features:
 
 Bug fixes:
 
+- Changed ``Topic`` to ``Collection`` in linkable items.  Since Plone
+  4.2 the type is called Collection.  No migration is done, because
+  existing sites may still have the old type, or may have decided not
+  to make any old- or new-style collections linkable.  [maurits]
+
 - Removed ``Large Plone Folder`` from settings.  This type is no
   longer added in Plone 4.  No migration is done, so existing sites
   will keep it, which is harmless.  [maurits]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,9 +15,17 @@ New features:
 
 Bug fixes:
 
+- Synchronised list of attributes in profile and export/import.  Now
+  when you export the tinymce settings of a fresh Plone Site and
+  import them again in purge mode, for example with a snapshot, you no
+  longer get extra items.  For example, the linkable objects would get
+  an extra ``ATDocument`` next to ``Document``, and two fancy table
+  styles would be added.  [maurits]
+
 - Export and import plugins, link_shortcuts, and image_shortcuts.
   Issue https://github.com/plone/Products.TinyMCE/issues/141
   [maurits]
+
 
 1.3.20 (2016-04-25)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,10 @@ New features:
 
 Bug fixes:
 
+- Removed ``Large Plone Folder`` from settings.  This type is no
+  longer added in Plone 4.  No migration is done, so existing sites
+  will keep it, which is harmless.  [maurits]
+
 - Synchronised list of attributes in profile and export/import.  Now
   when you export the tinymce settings of a fresh Plone Site and
   import them again in purge mode, for example with a snapshot, you no

--- a/Products/TinyMCE/exportimport.py
+++ b/Products/TinyMCE/exportimport.py
@@ -17,8 +17,29 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
             'editor_height': {'type': 'Text', 'default': u'400'},
             'contextmenu': {'type': 'Bool', 'default': True},
             'content_css': {'type': 'Text', 'default': u''},
-            'styles': {'type': 'List', 'default': u'Heading|h2| \nSubheading|h3| \nLiteral|pre| \nDiscreet|p|discreet\nPull-quote|div|pullquote\nCall-out|p|callout\nHighlight|span|visualHighlight\nOdd row|tr|odd\nEven row|tr|even\nHeading cell|th| \nPage break (print only)|div|pageBreak\nClear floats|div|visualClear'},
-            'tablestyles': {'type': 'List', 'default': u'Subdued grid|plain\nInvisible grid|invisible\nFancy listing|listing\nFancy grid listing|grid listing\nFancy vertical listing|vertical listing'},
+            'styles': {
+                'type': 'List', 'default':
+                u'Heading|h2| \n'
+                u'Subheading|h3| \n'
+                u'Literal|pre| \n'
+                u'Discreet|p|discreet\n'
+                u'Pull-quote|div|pullquote\n'
+                u'Call-out|p|callout\n'
+                u'Highlight|span|visualHighlight\n'
+                u'Odd row|tr|odd\n'
+                u'Even row|tr|even\n'
+                u'Heading cell|th| \n'
+                u'Page break (print only)|div|pageBreak\n'
+                u'Clear floats|div|visualClear\n'
+            },
+            'tablestyles': {
+                'type': 'List', 'default':
+                u'Subdued grid|plain\n'
+                u'Invisible grid|invisible\n'
+                u'Fancy listing|listing\n'
+                u'Fancy grid listing|grid listing\n'
+                u'Fancy vertical listing|vertical listing\n'
+            },
         },
         'toolbar': {
             'toolbar_width': {'type': 'Text', 'default': u'440'},
@@ -80,9 +101,30 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
         'resourcetypes': {
             'link_using_uids': {'type': 'Bool', 'default': False},
             'allow_captioned_images': {'type': 'Bool', 'default': False},
-            'containsobjects': {'type': 'List', 'default': u'ATFolder\nATBTreeFolder\nPlone Site'},
-            'containsanchors': {'type': 'List', 'default': u'ATEvent\nATNewsItem\nATDocument\nATRelativePathCriterion'},
-            'linkable': {'type': 'List', 'default': u'ATTopic\nATEvent\nATFile\nATFolder\nATImage\nATBTreeFolder\nATNewsItem\nATDocument'},
+            'containsobjects': {
+                'type': 'List', 'default':
+                u'ATFolder\n'
+                u'ATBTreeFolder\n'
+                u'Plone Site\n'
+            },
+            'containsanchors': {
+                'type': 'List', 'default':
+                u'ATEvent\n'
+                u'ATNewsItem\n'
+                u'ATDocument\n'
+                u'ATRelativePathCriterion\n'
+            },
+            'linkable': {
+                'type': 'List', 'default':
+                u'ATTopic\n'
+                u'ATEvent\n'
+                u'ATFile\n'
+                u'ATFolder\n'
+                u'ATImage\n'
+                u'ATBTreeFolder\n'
+                u'ATNewsItem\n'
+                u'ATDocument\n'
+            },
             'imageobjects': {'type': 'List', 'default': u'ATImage'},
             'plugins': {'type': 'Selection', 'default': []},
             'customplugins': {'type': 'List', 'default': u''},

--- a/Products/TinyMCE/exportimport.py
+++ b/Products/TinyMCE/exportimport.py
@@ -19,16 +19,16 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
             'content_css': {'type': 'Text', 'default': u''},
             'styles': {
                 'type': 'List', 'default':
-                u'Heading|h2| \n'
-                u'Subheading|h3| \n'
-                u'Literal|pre| \n'
-                u'Discreet|p|discreet\n'
-                u'Pull-quote|div|pullquote\n'
+                u'Heading|h2|\n'
+                u'Subheading|h3|\n'
+                u'Literal|pre|\n'
+                u'Discreet|span|discreet\n'
+                u'Pull-quote|blockquote|pullquote\n'
                 u'Call-out|p|callout\n'
                 u'Highlight|span|visualHighlight\n'
                 u'Odd row|tr|odd\n'
                 u'Even row|tr|even\n'
-                u'Heading cell|th| \n'
+                u'Heading cell|th|\n'
                 u'Page break (print only)|div|pageBreak\n'
                 u'Clear floats|div|visualClear\n'
             },
@@ -37,8 +37,6 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
                 u'Subdued grid|plain\n'
                 u'Invisible grid|invisible\n'
                 u'Fancy listing|listing\n'
-                u'Fancy grid listing|grid listing\n'
-                u'Fancy vertical listing|vertical listing\n'
             },
         },
         'toolbar': {
@@ -103,29 +101,29 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
             'allow_captioned_images': {'type': 'Bool', 'default': False},
             'containsobjects': {
                 'type': 'List', 'default':
-                u'ATFolder\n'
-                u'ATBTreeFolder\n'
+                u'Folder\n'
+                u'Large Plone Folder\n'
                 u'Plone Site\n'
             },
             'containsanchors': {
                 'type': 'List', 'default':
-                u'ATEvent\n'
-                u'ATNewsItem\n'
-                u'ATDocument\n'
+                u'Event\n'
+                u'News Item\n'
+                u'Document\n'
                 u'ATRelativePathCriterion\n'
             },
             'linkable': {
                 'type': 'List', 'default':
-                u'ATTopic\n'
-                u'ATEvent\n'
-                u'ATFile\n'
-                u'ATFolder\n'
-                u'ATImage\n'
-                u'ATBTreeFolder\n'
-                u'ATNewsItem\n'
-                u'ATDocument\n'
+                u'Topic\n'
+                u'Event\n'
+                u'File\n'
+                u'Folder\n'
+                u'Image\n'
+                u'Large Plone Folder\n'
+                u'News Item\n'
+                u'Document\n'
             },
-            'imageobjects': {'type': 'List', 'default': u'ATImage'},
+            'imageobjects': {'type': 'List', 'default': u'Image'},
             'plugins': {'type': 'Selection', 'default': []},
             'customplugins': {'type': 'List', 'default': u''},
             'entity_encoding': {'type': 'Text', 'default': u'raw'},

--- a/Products/TinyMCE/exportimport.py
+++ b/Products/TinyMCE/exportimport.py
@@ -113,7 +113,7 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
             },
             'linkable': {
                 'type': 'List', 'default':
-                u'Topic\n'
+                u'Collection\n'
                 u'Event\n'
                 u'File\n'
                 u'Folder\n'

--- a/Products/TinyMCE/exportimport.py
+++ b/Products/TinyMCE/exportimport.py
@@ -102,7 +102,6 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
             'containsobjects': {
                 'type': 'List', 'default':
                 u'Folder\n'
-                u'Large Plone Folder\n'
                 u'Plone Site\n'
             },
             'containsanchors': {
@@ -119,7 +118,6 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
                 u'File\n'
                 u'Folder\n'
                 u'Image\n'
-                u'Large Plone Folder\n'
                 u'News Item\n'
                 u'Document\n'
             },

--- a/Products/TinyMCE/exportimport.py
+++ b/Products/TinyMCE/exportimport.py
@@ -106,20 +106,20 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
             },
             'containsanchors': {
                 'type': 'List', 'default':
+                u'ATRelativePathCriterion\n'
+                u'Document\n'
                 u'Event\n'
                 u'News Item\n'
-                u'Document\n'
-                u'ATRelativePathCriterion\n'
             },
             'linkable': {
                 'type': 'List', 'default':
                 u'Collection\n'
+                u'Document\n'
                 u'Event\n'
                 u'File\n'
                 u'Folder\n'
                 u'Image\n'
                 u'News Item\n'
-                u'Document\n'
             },
             'imageobjects': {'type': 'List', 'default': u'Image'},
             'plugins': {'type': 'Selection', 'default': []},

--- a/Products/TinyMCE/profiles/default/tinymce.xml
+++ b/Products/TinyMCE/profiles/default/tinymce.xml
@@ -6,22 +6,22 @@
   <rooted value="False"/>
   <linkable>
    <element value="Collection"/>
+   <element value="Document"/>
    <element value="Event"/>
    <element value="File"/>
    <element value="Folder"/>
    <element value="Image"/>
    <element value="News Item"/>
-   <element value="Document"/>
   </linkable>
   <containsobjects>
    <element value="Folder"/>
    <element value="Plone Site"/>
   </containsobjects>
   <containsanchors>
+   <element value="ATRelativePathCriterion"/>
+   <element value="Document"/>
    <element value="Event"/>
    <element value="News Item"/>
-   <element value="Document"/>
-   <element value="ATRelativePathCriterion"/>
   </containsanchors>
   <imageobjects>
    <element value="Image"/>

--- a/Products/TinyMCE/profiles/default/tinymce.xml
+++ b/Products/TinyMCE/profiles/default/tinymce.xml
@@ -10,13 +10,11 @@
    <element value="File"/>
    <element value="Folder"/>
    <element value="Image"/>
-   <element value="Large Plone Folder"/>
    <element value="News Item"/>
    <element value="Document"/>
   </linkable>
   <containsobjects>
    <element value="Folder"/>
-   <element value="Large Plone Folder"/>
    <element value="Plone Site"/>
   </containsobjects>
   <containsanchors>

--- a/Products/TinyMCE/profiles/default/tinymce.xml
+++ b/Products/TinyMCE/profiles/default/tinymce.xml
@@ -5,7 +5,7 @@
   <allow_captioned_images value="False"/>
   <rooted value="False"/>
   <linkable>
-   <element value="Topic"/>
+   <element value="Collection"/>
    <element value="Event"/>
    <element value="File"/>
    <element value="Folder"/>


### PR DESCRIPTION
This pull request synchronises the defaults in `exportimport.py` and `tinymce.xml`. And it updates types to more modern Plone versions: Topic to Collection, and no longer a Plone Large Folder.
Theoretically we could add migration, but it seems not very useful.