### PR TITLE
Added tablerowstyles setting in control panel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,10 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Added ``tablerowstyles`` setting in control panel.  These styles are
+  available when you are setting the table row properties.  Until now,
+  all styles were shown here, most of which are not useful for table
+  rows, and they were shown in an ugly and wrong way.  [maurits]
 
 Bug fixes:
 

--- a/Products/TinyMCE/exportimport.py
+++ b/Products/TinyMCE/exportimport.py
@@ -38,6 +38,11 @@ class TinyMCESettingsXMLAdapter(XMLAdapterBase):
                 u'Invisible grid|invisible\n'
                 u'Fancy listing|listing\n'
             },
+            'tablerowstyles': {
+                'type': 'List', 'default':
+                u'Even|even\n'
+                u'Odd|odd\n'
+            },
         },
         'toolbar': {
             'toolbar_width': {'type': 'Text', 'default': u'440'},

--- a/Products/TinyMCE/interfaces/utility.py
+++ b/Products/TinyMCE/interfaces/utility.py
@@ -92,6 +92,11 @@ class ITinyMCELayout(Interface):
         description=_(u"Enter a list of styles to appear in the table style pulldown. Format is title|class, one per line."),
         required=False)
 
+    tablerowstyles = schema.Text(
+        title=_(u"Table row styles"),
+        description=_(u"Enter a list of styles to appear in the table row style pulldown. Format is title|class, one per line."),
+        required=False)
+
 
 class ITinyMCEToolbar(Interface):
     """This interface defines the toolbar properties."""

--- a/Products/TinyMCE/profiles.zcml
+++ b/Products/TinyMCE/profiles.zcml
@@ -109,6 +109,15 @@
         handler=".upgrades.upgrade_to_profile_8"
         />
 
+   <genericsetup:upgradeStep
+        title="Upgrade TinyMCE 1.3.22 to 1.3.23"
+        description="Add default tablerowstyles"
+        source="8"
+        destination="9"
+        profile="Products.TinyMCE:TinyMCE"
+        handler=".upgrades.upgrade_to_profile_9"
+        />
+
     <genericsetup:upgradeStep
         title="Install plone.outputfilters"
         description="This replaces the old TinyMCE-specific resolveuid and captioning transform."

--- a/Products/TinyMCE/profiles/default/metadata.xml
+++ b/Products/TinyMCE/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>8</version>
+  <version>9</version>
   <dependencies>
     <dependency>profile-plone.outputfilters:default</dependency>
     <dependency>profile-plone.app.imaging:default</dependency>

--- a/Products/TinyMCE/profiles/default/tinymce.xml
+++ b/Products/TinyMCE/profiles/default/tinymce.xml
@@ -66,6 +66,10 @@
    <element value="Invisible grid|invisible"/>
    <element value="Fancy listing|listing"/>
   </tablestyles>
+  <tablerowstyles>
+   <element value="Even|even"/>
+   <element value="Odd|odd"/>
+  </tablerowstyles>
   <resizing value="True"/>
  </layout>
  <toolbar>

--- a/Products/TinyMCE/upgrades.py
+++ b/Products/TinyMCE/upgrades.py
@@ -103,3 +103,13 @@ def upgrade_to_profile_8(context):
     tdata.append('vertical-align')
     transform._p_changed = True
     transform.reload()
+
+
+def upgrade_to_profile_9(context):
+    tinymce = getToolByName(context, 'portal_tinymce')
+    if tinymce.tablerowstyles:
+        return
+    tinymce.tablerowstyles = (
+        u'Even|even\n'
+        u'Odd|odd\n'
+    )

--- a/Products/TinyMCE/utility.py
+++ b/Products/TinyMCE/utility.py
@@ -94,6 +94,7 @@ class TinyMCE(SimpleItem):
     styles = FieldProperty(ITinyMCELayout['styles'])
     formats = FieldProperty(ITinyMCELayout['formats'])
     tablestyles = FieldProperty(ITinyMCELayout['tablestyles'])
+    tablerowstyles = FieldProperty(ITinyMCELayout['tablerowstyles'])
 
     toolbar_width = FieldProperty(ITinyMCEToolbar['toolbar_width'])
 
@@ -760,6 +761,7 @@ class TinyMCE(SimpleItem):
         # Add styles to results
         results['styles'] = []
         table_styles = []
+        table_row_styles = []
         if not redefine_parastyles:
             if isinstance(self.tablestyles, StringTypes):
                 for tablestyle in self.tablestyles.split('\n'):
@@ -777,6 +779,22 @@ class TinyMCE(SimpleItem):
                         tablestyletitle = translate(_(tablestylefields[0]), context=request)
                     results['styles'].append(tablestyletitle + '|table|' + tablestyleid)
                     table_styles.append(tablestyletitle + '=' + tablestyleid)
+            if isinstance(self.tablerowstyles, StringTypes):
+                for tablerowstyle in self.tablerowstyles.split('\n'):
+                    if not tablerowstyle:
+                        # empty line
+                        continue
+                    tablerowstylefields = tablerowstyle.split('|')
+                    tablerowstyletitle = tablerowstylefields[0]
+                    tablerowstyleid = tablerowstylefields[1]
+                    if tablerowstyleid == 'plain':
+                        # Do not duplicate the default style hardcoded in the
+                        # table.htm.pt
+                        continue
+                    if request is not None:
+                        tablerowstyletitle = translate(_(tablerowstylefields[0]), context=request)
+                    results['styles'].append(tablerowstyletitle + '|tr|' + tablerowstyleid)
+                    table_row_styles.append(tablerowstyletitle + '=' + tablerowstyleid)
             if isinstance(self.styles, StringTypes):
                 styles = []
                 for style in self.styles.split('\n'):
@@ -791,6 +809,7 @@ class TinyMCE(SimpleItem):
                     styles.append(merge)
                 results['styles'].extend(styles)
         results['table_styles'] = ';'.join(table_styles)  # tinymce config
+        results['table_row_styles'] = ';'.join(table_row_styles)
 
         if parastyles is not None:
             results['styles'].extend(parastyles)


### PR DESCRIPTION
These styles are available when you are setting the table row properties.  Until now, all styles were shown here, most of which are not useful for table rows, and they were shown in an ugly and wrong way.

Note that this went wrong probably since Products.TinyMCE 1.3. In row.js this does:

    addClassesToList('class', 'table_row_styles');

But `table_row_styles` was not available in the json configuration, so addClassesToList fell back to the `advanced_styles`, which resulted in a dictionary being shown as option:

<img width="229" alt="screen shot 2016-07-12 at 12 50 51" src="https://cloud.githubusercontent.com/assets/210587/16765779/63ca47c4-4836-11e6-8467-41f23b5d0991.png">

With this pull request, it looks like this:

![screen shot 2016-07-12 at 12 52 49](https://cloud.githubusercontent.com/assets/210587/16765788/7c4073d2-4836-11e6-8346-92c3d8b9342a.png)

