### PR TITLE
improve item-listing in link dialog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,12 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Crop description text in link dialog to 60 chars
+  (less json data to transmit for folders containing a lot of articles)
+  [fRiSi]
+
+- Show path in alt-text of articles too (to distinguish Items having the
+  same title) [fRiSi]
 
 Bug fixes:
 

--- a/Products/TinyMCE/adapters/JSONFolderListing.py
+++ b/Products/TinyMCE/adapters/JSONFolderListing.py
@@ -106,9 +106,9 @@ class JSONFolderListing(object):
             results['path'] = self.getBreadcrumbs()
 
         plone_layout = self.context.restrictedTraverse('@@plone_layout', None)
+        plone_view = self.context.restrictedTraverse('@@plone')
         if plone_layout is None:
             # Plone 3
-            plone_view = self.context.restrictedTraverse('@@plone')
             getIcon = lambda brain: plone_view.getIcon(brain).html_tag()
         else:
             # Plone >= 4
@@ -120,6 +120,7 @@ class JSONFolderListing(object):
         query.update({'portal_type': filter_portal_types,
                       'sort_on': 'getObjPositionInParent',
                       'path': {'query': path, 'depth': 1}})
+
         for brain in portal_catalog(**query):
 
             description = ''
@@ -128,6 +129,7 @@ class JSONFolderListing(object):
                     description = unicode(brain.Description, 'utf-8', 'ignore')
                 elif type(brain.Description) == unicode:
                     description = brain.Description
+                description = plone_view.cropText(description, 60)
 
             catalog_results.append({
                 'id': brain.getId,
@@ -140,6 +142,7 @@ class JSONFolderListing(object):
                 'icon': getIcon(brain),
                 'description': description,
                 'is_folderish': brain.is_folderish,
+                'path': brain.getPath(),
                 })
 
         # add catalog_ressults

--- a/Products/TinyMCE/adapters/JSONSearch.py
+++ b/Products/TinyMCE/adapters/JSONSearch.py
@@ -51,6 +51,7 @@ class JSONSearch(object):
                     'icon': getIcon(brain),
                     'description': brain.Description,
                     'is_folderish': brain.is_folderish,
+                    'path': brain.getPath(),
                     } for brain in brains if brain]
 
         # add catalog_results

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -882,7 +882,7 @@ BrowserDialog.prototype.getFolderListing = function (context_url, method) {
                                 ]);
                             } else {
                                 jq.merge(item_html, [
-                                    '<div class="item list ' + (i % 2 === 0 ? 'even' : 'odd') + '" title="' + item.description + '">',
+                                    '<div class="item list ' + (i % 2 === 0 ? 'even' : 'odd') + '" title="' + item.description + ((item.description) ? '&#13;&#13;' : '') + item.path + '">',
                                         '<input href="' + item.url + '" ',
                                             'type="radio" class="noborder" style="margin: 0; width: 16px" name="internallink" value="',
                                             'resolveuid/' + item.uid ,

--- a/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
+++ b/Products/TinyMCE/skins/tinymce/plugins/plonebrowser/js/plonebrowser.js
@@ -875,7 +875,7 @@ BrowserDialog.prototype.getFolderListing = function (context_url, method) {
                                 }
                                 jq.merge(folder_html, [
                                         item.icon,
-                                        '<a href="' + item.url + '" class="folderlink contenttype-' + item.normalized_type + ' state-' + item.review_state + '">',
+                                        '<a href="' + item.url + '" class="folderlink contenttype-' + item.normalized_type + ' state-' + item.review_state + '" title="' + item.description + ((item.description) ? '&#13;&#13;' : '') + item.path + '">',
                                             item.title,
                                         '</a>',
                                     '</div>'


### PR DESCRIPTION
one of our clients has a lot of events with the same title and needs a way to tell them apart when creating links to them in tiny. currently there is no way to distinguish non-folderish istems with the same title:

![tiny-vorher](https://cloud.githubusercontent.com/assets/1120517/23308181/8c918eb6-faaa-11e6-8205-ef45b0330115.jpg)


this pr adds the path to the alt text and crops the description (we can argue about the number of characters here though ;-)

![tiny-nachher1](https://cloud.githubusercontent.com/assets/1120517/23308230/c351897e-faaa-11e6-9d78-e80f53dddd39.png)



## changes

* crop description to transmit less json data

* show path in alt-text to distinguish articles with the same title (yes, this more or less compensates the savings made by cropping the description)

