### PR TITLE
Add missing import in the DX anchor view module.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ HISTORY
 1.4.4 (unreleased)
 ------------------
 
+- Add missing import in the DX anchor view module.
+  [mbaechtold]
+
 - Media button broken (issue #14249).
   [malthe]
 

--- a/Products/TinyMCE/browser/dxanchors.py
+++ b/Products/TinyMCE/browser/dxanchors.py
@@ -2,6 +2,7 @@
 
 from Products.Five.browser import BrowserView
 from Products.TinyMCE.browser.interfaces.anchors import IAnchorView
+from ZODB.POSException import ConflictError
 from plone.dexterity.utils import iterSchemata
 from plone.rfc822.interfaces import IPrimaryField
 from zope.interface import implements


### PR DESCRIPTION
A backport to the 1.3.x branch will be added once this has been merged.