### PR TITLE
Location of sauna.reload updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ report
 include
 lib
 dist
+eggs
 tinymce_language_pack
 docs/build

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Updated URL of sauna.reload [tobiasherp]
 
 
 1.3.27 (2017-04-08)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -40,7 +40,7 @@ defaults = ['--coverage', '../../coverage', '-v', '--auto-progress', '-s', 'Prod
 
 [sources]
 tinymce = git https://github.com/collective/tinymce.git egg=false branch=3.4.7-plone update=true
-sauna.reload = git git://github.com/collective/sauna.reload.git
+sauna.reload = git https://github.com/collective/sauna.reload.git
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -40,7 +40,7 @@ defaults = ['--coverage', '../../coverage', '-v', '--auto-progress', '-s', 'Prod
 
 [sources]
 tinymce = git https://github.com/collective/tinymce.git egg=false branch=3.4.7-plone update=true
-sauna.reload = git git://github.com/epeli/sauna.reload.git
+sauna.reload = git git://github.com/collective/sauna.reload.git
 
 [instance]
 recipe = plone.recipe.zope2instance


### PR DESCRIPTION
The sauna.reload package has moved to github.com/collective/;
anonymous clone requires https:// protocol.